### PR TITLE
Delete Google Code-IN

### DIFF
--- a/oss-programs/google-code-in.md
+++ b/oss-programs/google-code-in.md
@@ -1,2 +1,0 @@
-# Google Code-In
-


### PR DESCRIPTION
Google ended Google Code-In, so I think it will be best to remove it from the docs.

