### PR TITLE
fixed a typo in the chapter-leads-onboarding-guide

### DIFF
--- a/community/chapters/chapter-leads-onboarding-guide.md
+++ b/community/chapters/chapter-leads-onboarding-guide.md
@@ -6,7 +6,7 @@ Our goal is to increase the rate of credible contributions by African software d
 
 ![](../../.gitbook/assets/nxtbc.png)
 
-### What does it mean to be an OSCA Chapter Lead? 
+### What does it mean to be an OSCA Chapter Lead?
 
 As an OSCA chapter lead, you represent a global network of open-source enthusiasts and you are responsible for growing and supporting vibrant local OSCA communities in Africa.
 
@@ -14,7 +14,7 @@ As an OSCA chapter lead, you represent a global network of open-source enthusias
 
 > Alone we can do so little, together we can do so much.
 
-Check out our community code of conduct below 👇 
+Check out our community code of conduct below 👇
 
 {% page-ref page="../../about/community-code-of-conduct.md" %}
 
@@ -24,35 +24,35 @@ Successful leads ensure that the local community they lead embodies OSCA’s cor
 
 #### Promote Open Source Community Africa in your City.
 
-* Evangelize the OSCA program within your local tech community.
-* Share updates about your chapter through your different social media channels \(LinkedIn, Twitter, Facebook, Whatsapp, etc.\)
-* Act as a mentor to the community; connecting people, and identifying partnerships.
+- Evangelize the OSCA program within your local tech community.
+- Share updates about your chapter through your different social media channels \(LinkedIn, Twitter, Facebook, Whatsapp, etc.\)
+- Act as a mentor to the community; connecting people, and identifying partnerships.
 
 #### Lead an engaged Discord communication Channel for your chapter.
 
-* Promote ongoing discussion and knowledge sharing.
-* Post content and resources about open-source frequently.
-* Understand your community members’ interests.
+- Promote ongoing discussion and knowledge sharing.
+- Post content and resources about open-source frequently.
+- Understand your community members’ interests.
 
 #### Host events.
 
-* Plan a physical meet up at least once in three months to avoid being blacklisted. 
-* Invite local or global technical/non-technical speakers with experience in the covered topics.
-* Communicate and partner with local communities, tech hubs, and influencers.
+- Plan a physical meet up at least once in three months to avoid being blacklisted.
+- Invite local or global technical/non-technical speakers with experience in the covered topics.
+- Communicate and partner with local communities, tech hubs, and influencers.
 
 #### Coordinate with OSCA’s community managers.
 
-* Participate in the monthly review meeting with your community manager.
-* Coordinate with the Open Source Community Africa for support in planning your event \(swag, promotion, etc.\). 
-* Submit event reports after every meetup/event you organize for your local community.
+- Participate in the monthly review meeting with your community manager.
+- Coordinate with the Open Source Community Africa for support in planning your event \(swag, promotion, etc.\).
+- Submit event reports after every meetup/event you organize for your local community.
 
 ### Social Media
 
-As an OSCA lead, you represent us and our value and we implore you to use any hate speech on social media. Find below guides to follow via interacting with members of your community:
+As an OSCA lead, you represent us and our value and we implore you not to use any hate speech on social media. Find below guides to follow via interacting with members of your community:
 
 1. Create a Twitter account for your chapter and customize the account.
 2. Ensure that the account name always starts with OSCA followed by the chapter name \(e.g OSCA Lagos\), and the handle should be OSCA \(in lowercase\) followed by the chapter name \(e.g @oscalagos or @osca-lagos\).
-3. Upon creating a social account for your chapter, kindly copy, edit and use this for your chapter’s bio: "_Open Source Community Africa \[insert chapter name\] is a chapter of_[ __](https://twitter.com/SheCodeAfrica)\_\_[_@oscafrica_](https://twitter.com/oscafrica) _focused on increasing the rate of credible contributions by Africans to open source projects both locally and globally in \[Chapter’s city, Country\]_."
+3. Upon creating a social account for your chapter, kindly copy, edit and use this for your chapter’s bio: "_Open Source Community Africa \[insert chapter name\] is a chapter of_[ \_\_](https://twitter.com/SheCodeAfrica)\_\_[_@oscafrica_](https://twitter.com/oscafrica) _focused on increasing the rate of credible contributions by Africans to open source projects both locally and globally in \[Chapter’s city, Country\]_."
 4. Always tag @oscafrica when creating awareness about your events or initiatives.
 5. Use the hashtags like **\#OSCAUyo**. That is, \#OSCA{City of your chapter}
 6. When giving out information, ensure that it is from a reliable source.
@@ -62,11 +62,11 @@ As an OSCA lead, you represent us and our value and we implore you to use any ha
 
 As an OSCA lead, you are expected to use this design template to guide every event you organize.
 
-Color code: 
+Color code:
 
 Logo:
 
-Font: 
+Font:
 
 Design Samples:
 
@@ -76,11 +76,10 @@ Design Samples:
 
 As an OSCA Chapter Lead, you will use the [Chapter Leads Hub](https://github.com/oscafrica/chapter-leads-hub) for:
 
-* Discussing and planning chapter activities.
-* Requesting help, support, or materials from Open Source Community Africa. 
-* Tracking and talking about the activities you are organizing.
-* Checking out the docs for chapter design assets, managing expenses, and sponsorship information.
-* Anything else a Chapter Lead needs to be successful.
+- Discussing and planning chapter activities.
+- Requesting help, support, or materials from Open Source Community Africa.
+- Tracking and talking about the activities you are organizing.
+- Checking out the docs for chapter design assets, managing expenses, and sponsorship information.
+- Anything else a Chapter Lead needs to be successful.
 
-###  
-
+###


### PR DESCRIPTION
<!-- Love osca? Please consider supporting our collective:
👉  https://opencollective.com/osca/donate -->

#### This PR fixes a typo

#### On the social media section of the chapter-leads-onboarding-guide, Statement on hate speech. It says "we Implore you to use any hate speech on social media" The word NOT didn't appear in the statement. This PR fixed that.

